### PR TITLE
Add more functionality - delay, failrate, better logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It can be used for testing programs that make requests to a web server. The valu
 | [/500](http://localhost:8080/500) | 500 | "Internal server error" |  |
 | [/headers](http://localhost:8080/headers) | 200 | Client headers |  |
 | [?delay=N](http://localhost:8080/200?delay=3) | * | * | Delay for N seconds |
-| [?failrate=N](http://localhost:8080/200?failrate=50) | * | * | N% change request will fail |
+| [?failrate=N](http://localhost:8080/200?failrate=50) | * | * | N% of requests will fail |
 
 ## Running the server
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ It can be used for testing programs that make requests to a web server. The valu
 | [/404](http://localhost:8080/404) | 404 | "Page not found" |  |
 | [/500](http://localhost:8080/500) | 500 | "Internal server error" |  |
 | [/headers](http://localhost:8080/headers) | 200 | Client headers |  |
-| [/delay](http://localhost:8080/delay) | 200 | Info about the delay | Delay for N seconds (default 1; query arg like `?delay=2`) |
+| [?delay=N](http://localhost:8080/200?delay=3) | * | * | Delay for N seconds |
+| [?failrate=N](http://localhost:8080/200?failrate=50) | * | * | N% change request will fail |
 
 ## Running the server
 
@@ -26,7 +27,7 @@ The web server can be run as-is using `go run`:
 
 ```text
 $ go run main.go
-Server starting on http://localhost:8080
+2025/02/24 22:18:30 Server starting on http://localhost:8080
 ```
 
 It can also be compiled into a binary for easier portability:
@@ -42,12 +43,12 @@ It takes `-port` as an optional argument, allowing you to specify which port the
 
 ```text
 $ go run main.go -port 48080
-Server starting on http://localhost:48080
+2025/02/24 22:18:30 Server starting on http://localhost:48080
 ```
 
 ```text
 $ ./trusty_web_server -port 48080
-Server starting on http://localhost:48080
+2025/02/24 22:18:30 Server starting on http://localhost:48080
 ```
 
 ## Resources and References

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It can be used for testing programs that make requests to a web server. The valu
 | [/404](http://localhost:8080/404) | 404 | "Page not found" |  |
 | [/500](http://localhost:8080/500) | 500 | "Internal server error" |  |
 | [/headers](http://localhost:8080/headers) | 200 | Client headers |  |
+| [/delay](http://localhost:8080/delay) | 200 | Info about the delay | Delay for N seconds (default 1; query arg like `?delay=2`) |
 
 ## Running the server
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"fmt"
+	"log"
 	"net/http"
 
 	"httpfunctions"
@@ -24,8 +24,7 @@ func main() {
 	http.Handle("/500", httpfunctions.HTTPMiddleware(http.HandlerFunc(httpfunctions.Respond_500)))
 
 	http.Handle("/headers", httpfunctions.HTTPMiddleware(http.HandlerFunc(httpfunctions.Respond_headers)))
-	http.HandleFunc("/delay", httpfunctions.Respond_delay)
 
-	fmt.Printf("Server starting on http://localhost:%s\n", *port)
+	log.Printf("Server starting on http://localhost:%s\n", *port)
 	http.ListenAndServe(":"+*port, nil)
 }

--- a/main.go
+++ b/main.go
@@ -12,18 +12,18 @@ func main() {
 	port := flag.String("port", "8080", "Port to run the local web server")
 	flag.Parse()
 
-	http.Handle("/ok", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_ok)))
-	http.Handle("/degraded", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_degraded)))
-	http.Handle("/outage", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_outage)))
+	http.Handle("/ok", httpfunctions.HTTPMiddleware(http.HandlerFunc(httpfunctions.Respond_ok)))
+	http.Handle("/degraded", httpfunctions.HTTPMiddleware(http.HandlerFunc(httpfunctions.Respond_degraded)))
+	http.Handle("/outage", httpfunctions.HTTPMiddleware(http.HandlerFunc(httpfunctions.Respond_outage)))
 
-	http.Handle("/200", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_200)))
-	http.Handle("/301", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_301)))
-	http.Handle("/302", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_302)))
-	http.Handle("/401", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_401)))
-	http.Handle("/404", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_404)))
-	http.Handle("/500", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_500)))
+	http.Handle("/200", httpfunctions.HTTPMiddleware(http.HandlerFunc(httpfunctions.Respond_200)))
+	http.Handle("/301", httpfunctions.HTTPMiddleware(http.HandlerFunc(httpfunctions.Respond_301)))
+	http.Handle("/302", httpfunctions.HTTPMiddleware(http.HandlerFunc(httpfunctions.Respond_302)))
+	http.Handle("/401", httpfunctions.HTTPMiddleware(http.HandlerFunc(httpfunctions.Respond_401)))
+	http.Handle("/404", httpfunctions.HTTPMiddleware(http.HandlerFunc(httpfunctions.Respond_404)))
+	http.Handle("/500", httpfunctions.HTTPMiddleware(http.HandlerFunc(httpfunctions.Respond_500)))
 
-	http.Handle("/headers", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_headers)))
+	http.Handle("/headers", httpfunctions.HTTPMiddleware(http.HandlerFunc(httpfunctions.Respond_headers)))
 	http.HandleFunc("/delay", httpfunctions.Respond_delay)
 
 	fmt.Printf("Server starting on http://localhost:%s\n", *port)

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ func main() {
 	http.HandleFunc("/500", httpfunctions.Respond_500)
 
 	http.HandleFunc("/headers", httpfunctions.Respond_headers)
+	http.HandleFunc("/delay", httpfunctions.Respond_delay)
 
 	fmt.Printf("Server starting on http://localhost:%s\n", *port)
 	http.ListenAndServe(":"+*port, nil)

--- a/main.go
+++ b/main.go
@@ -9,22 +9,21 @@ import (
 )
 
 func main() {
-
 	port := flag.String("port", "8080", "Port to run the local web server")
 	flag.Parse()
 
-	http.HandleFunc("/ok", httpfunctions.Respond_ok)
-	http.HandleFunc("/degraded", httpfunctions.Respond_degraded)
-	http.HandleFunc("/outage", httpfunctions.Respond_outage)
+	http.Handle("/ok", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_ok)))
+	http.Handle("/degraded", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_degraded)))
+	http.Handle("/outage", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_outage)))
 
-	http.HandleFunc("/200", httpfunctions.Respond_200)
-	http.HandleFunc("/301", httpfunctions.Respond_301)
-	http.HandleFunc("/302", httpfunctions.Respond_302)
-	http.HandleFunc("/401", httpfunctions.Respond_401)
-	http.HandleFunc("/404", httpfunctions.Respond_404)
-	http.HandleFunc("/500", httpfunctions.Respond_500)
+	http.Handle("/200", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_200)))
+	http.Handle("/301", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_301)))
+	http.Handle("/302", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_302)))
+	http.Handle("/401", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_401)))
+	http.Handle("/404", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_404)))
+	http.Handle("/500", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_500)))
 
-	http.HandleFunc("/headers", httpfunctions.Respond_headers)
+	http.Handle("/headers", httpfunctions.DelayMiddleware(http.HandlerFunc(httpfunctions.Respond_headers)))
 	http.HandleFunc("/delay", httpfunctions.Respond_delay)
 
 	fmt.Printf("Server starting on http://localhost:%s\n", *port)

--- a/main.go
+++ b/main.go
@@ -26,6 +26,6 @@ func main() {
 
 	http.HandleFunc("/headers", httpfunctions.Respond_headers)
 
-	fmt.Printf("Server starting on http://localhost:" + *port + "\n")
+	fmt.Printf("Server starting on http://localhost:%s\n", *port)
 	http.ListenAndServe(":"+*port, nil)
 }

--- a/vendor/httpfunctions/httpfunctions.go
+++ b/vendor/httpfunctions/httpfunctions.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
+	"time"
 )
 
 //go:embed static
@@ -67,4 +69,19 @@ func Respond_headers(w http.ResponseWriter, req *http.Request) {
 			fmt.Fprintf(w, "%v: %v\n", name, h)
 		}
 	}
+}
+
+func Respond_delay(w http.ResponseWriter, req *http.Request) {
+	delay := req.URL.Query().Get("delay")
+	if delay == "" {
+		delay = "1"
+	}
+	delaySeconds, err := strconv.Atoi(delay)
+	if err != nil {
+		http.Error(w, "Invalid delay value", http.StatusBadRequest)
+		return
+	}
+	fmt.Fprintf(w, "Delaying for %d seconds starting at %s\n", delaySeconds, time.Now().Format(time.RFC3339))
+	time.Sleep(time.Duration(delaySeconds) * time.Second)
+	fmt.Fprintf(w, "Done delaying at %s\n", time.Now().Format(time.RFC3339))
 }

--- a/vendor/httpfunctions/httpfunctions.go
+++ b/vendor/httpfunctions/httpfunctions.go
@@ -42,8 +42,8 @@ func HTTPMiddleware(next http.Handler) http.Handler {
 					randomNumber := rand.Intn(100) + 1
 					w.Header().Set("X-Failrate-Percent", strconv.Itoa(failratePercent))
 					w.Header().Set("X-Random-Number", strconv.Itoa(randomNumber))
-					log.Printf("Fail check. Request must beat a %d to fail. Request rolled a D100 and got %d.\n", randomNumber, failratePercent)
-					if randomNumber < failratePercent {
+					log.Printf("Fail check: FAIL if failratePercent > randomNumber. Requested failratePercent is %d. System generated randomNumber %d.\n", failratePercent, randomNumber)
+					if failratePercent > randomNumber {
 						w.WriteHeader(500)
 						fmt.Fprintf(w, "Internal server error - Request failed successfully\n")
 						return

--- a/vendor/httpfunctions/httpfunctions.go
+++ b/vendor/httpfunctions/httpfunctions.go
@@ -21,6 +21,19 @@ func loadText(file string) string {
 	return string(contents)
 }
 
+func DelayMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		delay := r.URL.Query().Get("delay")
+		if delay != "" {
+			delaySeconds, err := strconv.Atoi(delay)
+			if err == nil {
+				time.Sleep(time.Duration(delaySeconds) * time.Second)
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 func Respond_ok(w http.ResponseWriter, req *http.Request) {
 	ok_text := loadText("static/appname-OK.json")
 	fmt.Fprintln(w, ok_text)

--- a/vendor/httpfunctions/httpfunctions.go
+++ b/vendor/httpfunctions/httpfunctions.go
@@ -42,7 +42,6 @@ func HTTPMiddleware(next http.Handler) http.Handler {
 					if randomNumber < failratePercent {
 						w.WriteHeader(500)
 						fmt.Fprintf(w, "Internal server error - Request failed successfully\n")
-						fmt.Fprintf(w, "Failrate: %d\nRandom Number: %d\n", failratePercent, randomNumber)
 						return
 					}
 				}


### PR DESCRIPTION
* Added support for query parameter `?delay=N` to allow requests to delay response by N seconds.
* Added support for query parameter `?failrate=N` to allow requests to specify they should fail N% of the time.
* Send back custom response headers indicating which delay or failrate values were used.
* Switched from `fmt` to `log` for timestamped outputs.